### PR TITLE
Remove dependence on nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source "http://rubygems.org"
 
 gem "rake"
 gem "github-markdown"
-gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ GEM
   remote: http://rubygems.org/
   specs:
     github-markdown (0.5.3)
-    nokogiri (1.5.9)
     rake (0.9.6)
 
 PLATFORMS
@@ -10,5 +9,4 @@ PLATFORMS
 
 DEPENDENCIES
   github-markdown
-  nokogiri
   rake


### PR DESCRIPTION
`nokogiri` 不要なのでー。
(`nokogiri` を使おうとしていた個所は、今は `bin/replace_titles.pl` を使っていると @kentaro に聞いた)
