### PR TITLE
HTMLエクスポート時にMarkdownファイルをファイル名でソートする

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task book: [:mobi, :epub]
 
 desc 'Create an html-formatted file'
 file html: Dir.glob('ja/*.md') do |t|
-  sh "bundle exec bin/export_html.rb #{t.prerequisites.join(' ')} > puppet-book.html"
+  sh "bundle exec bin/export_html.rb #{t.prerequisites.sort.join(' ')} > puppet-book.html"
 end
 
 desc 'Create a mobi-formatted file'


### PR DESCRIPTION
bin/export_html.rbを実行する時、章の並びがばらばらにならないでしょうか？
僕の環境（Ubuntu 13.04 Desktop）ではなったので、修正コミットをプルリクエストします。
@kentaro さんの環境で問題ないようであればリジェクトしてください。
